### PR TITLE
Added 'optexp' and 'assignment' to OptionType(Enum) to support options

### DIFF
--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -16,7 +16,10 @@ class OptionType(Enum):
 class OptionType(Enum):
     CALL = "call"
     PUT = "put"
-
+    # Next 2 lines added otherwise parsing will fail on option expiration or assignment
+    EXP = "optexp"
+    ASSIGN = "assignment"
+    
     def __repr__(self):
         return self.value
 


### PR DESCRIPTION
Added 'optexp' and 'assignment' to OptionType(Enum) to support options expiration and assignment
Without this there is an error when we query Tradier.get_history and we have some option expirations or assignments in the history. Tested and it works.