### PR TITLE
Various fixes in response to style warnings and validation errors when handling Tradier API responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ tox
 black
 isort
 pre-commit
+pydantic
 pytest
 pytest-cov
 pytest-dotenv

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, time
 from enum import Enum
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 BROKERAGE_ENDPOINT = "https://api.tradier.com/"
 SANDBOX_ENDPOINT = "https://sandbox.tradier.com/"
@@ -41,7 +41,7 @@ class Profile(BaseModel):
     id: str
     name: str
 
-    @validator("account", pre=True)
+    @field_validator("account", mode='before')
     @classmethod
     def to_list(cls, v):
         """The API sometimes returns a single account and sometimes a list. Always return a list here for

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -50,47 +50,47 @@ class Profile(BaseModel):
 
 
 class Margin(BaseModel):
-    fed_call: int
-    maintenance_call: int
+    fed_call: float
+    maintenance_call: float
     option_buying_power: float
     stock_buying_power: float
-    stock_short_value: int
-    sweep: int
+    stock_short_value: float
+    sweep: float
 
 
 class Cash(BaseModel):
     cash_available: float
-    sweep: int
+    sweep: float
     unsettled_funds: float
 
 
 class Pdt(BaseModel):
-    fed_call: int
-    maintenance_call: int
+    fed_call: float
+    maintenance_call: float
     option_buying_power: float
     stock_buying_power: float
-    stock_short_value: int
+    stock_short_value: float
 
 
 class Balances(BaseModel):
-    option_short_value: int
+    option_short_value: float
     total_equity: float
     account_number: str
     account_type: str
     close_pl: float
     current_requirement: float
-    equity: int
+    equity: float
     long_market_value: float
     market_value: float
     open_pl: float
     option_long_value: float
-    option_requirement: int
+    option_requirement: float
     pending_orders_count: int
-    short_market_value: int
+    short_market_value: float
     stock_long_value: float
     total_cash: float
-    uncleared_funds: int
-    pending_cash: int
+    uncleared_funds: float
+    pending_cash: float
     # Only one of the following three is required, based on `account_type`.
     margin: Optional[Margin] = None
     cash: Optional[Cash] = None

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -259,10 +259,10 @@ class Quote(BaseModel):
     week_52_high: float
     week_52_low: float
     bidsize: int
-    bidexch: str
+    bidexch: Optional[str]
     bid_date: datetime
     asksize: int
-    askexch: str
+    askexch: Optional[str]
     ask_date: datetime
     root_symbols: Optional[str] = None
     underlying: Optional[str] = None

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -19,7 +19,7 @@ class OptionType(Enum):
     # Next 2 lines added otherwise parsing will fail on option expiration or assignment
     EXP = "optexp"
     ASSIGN = "assignment"
-    
+
     def __repr__(self):
         return self.value
 

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -404,7 +404,7 @@ class MarketsAPIResponse(BaseModel):
 
 
 class OrderDetails(BaseModel):
-    id: str
+    id: int
     status: str
     partner_id: Optional[str]
 

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -11,11 +11,6 @@ SANDBOX_ENDPOINT = "https://sandbox.tradier.com/"
 class OptionType(Enum):
     CALL = "call"
     PUT = "put"
-
-
-class OptionType(Enum):
-    CALL = "call"
-    PUT = "put"
     # Next 2 lines added otherwise parsing will fail on option expiration or assignment
     EXP = "optexp"
     ASSIGN = "assignment"

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -282,7 +282,7 @@ class UnmatchedSymbols(BaseModel):
 
 class Quotes(BaseModel):
     quotes: List[Quote] = Field(alias="quote")
-    unmatched_symbols: Optional[UnmatchedSymbols]
+    unmatched_symbols: Optional[UnmatchedSymbols] = None
 
 
 class Options(BaseModel):

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -96,9 +96,10 @@ class Balances(BaseModel):
     total_cash: float
     uncleared_funds: int
     pending_cash: int
-    margin: Optional[Margin]
-    cash: Optional[Cash]
-    pdt: Optional[Pdt]
+    # Only one of the following three is required, based on `account_type`.
+    margin: Optional[Margin] = None
+    cash: Optional[Cash] = None
+    pdt: Optional[Pdt] = None
 
 
 class Position(BaseModel):

--- a/src/tradier_python/models.py
+++ b/src/tradier_python/models.py
@@ -409,5 +409,5 @@ class APIErrors(BaseModel):
 
 
 class OrderAPIResponse(BaseModel):
-    order: Optional[OrderDetails]
-    errors: Optional[APIErrors]
+    order: Optional[OrderDetails] = None
+    errors: Optional[APIErrors] = None

--- a/src/tradier_python/tradier_api.py
+++ b/src/tradier_python/tradier_api.py
@@ -30,7 +30,7 @@ class TradierAPI:
 
         if response.status_code != 200:
             raise TradierAPIError(
-                response.status_code, response.content.decode("utf-8")
+                response.status_code, response.content.decode("utf-8"), params
             )
         res_json = response.json()
         key = url.rsplit("/", 1)[-1]
@@ -568,6 +568,7 @@ class TradierAPI:
 class TradierAPIError(Exception):
     code: int
     message: str
+    params: dict
 
 
 @dataclass

--- a/src/tradier_python/tradier_api.py
+++ b/src/tradier_python/tradier_api.py
@@ -96,7 +96,7 @@ class TradierAPI:
         account_id=None,
         page: int = None,
         limit: int = None,
-        type: str = None,
+        history_type: str = None,
         start: date = None,
         end: date = None,
         symbol: str = None,
@@ -108,7 +108,7 @@ class TradierAPI:
         params = {
             "page": page,
             "limit": limit,
-            "type": type,
+            "type": history_type,
             "start": start,
             "end": end,
             "symbol": symbol,
@@ -159,13 +159,13 @@ class TradierAPI:
 
     def get_order(
         self,
-        id: str,
+        order_id: str,
         include_tags: bool = False,
         account_id=None,
     ):
         if account_id is None:
             account_id = self.default_account_id
-        url = f"/v1/accounts/{account_id}/orders/{id}"
+        url = f"/v1/accounts/{account_id}/orders/{order_id}"
         params = {"includeTags": include_tags}
         data = self.get(url, params)
         res = AccountsAPIResponse(**data)
@@ -446,7 +446,8 @@ class TradierAPI:
 
     def lookup_option_symbols(self, underlying: str) -> List[Symbol]:
         """
-        Get all options symbols for the given underlying. This will include additional option roots (ex. SPXW, RUTW) if applicable.
+        Get all options symbols for the given underlying. This will include additional option roots (ex. SPXW, RUTW) if
+        applicable.
         """
         url = "/v1/markets/options/lookup"
         params = {"underlying": underlying}
@@ -460,11 +461,11 @@ class TradierAPI:
     ) -> List[HistoricQuote]:
         """
         Get historical pricing for a security. This data will usually cover the entire lifetime of the company if
-        sending reasonable start/end times. You can fetch historical pricing for options by passing the OCC option symbol
-        (ex. AAPL220617C00270000) as the symbol.
+        sending reasonable start/end times. You can fetch historical pricing for options by passing the OCC option
+        symbol (ex. AAPL220617C00270000) as the symbol.
 
-        Notes: Historical data may not be dividend adjusted as this relies on the exchanges to report/adjust it properly.
-        Historical options data is not available for expired options.
+        Notes: Historical data may not be dividend adjusted as this relies on the exchanges to report/adjust it
+        properly. Historical options data is not available for expired options.
         """
         url = "/v1/markets/history"
         params = {"symbol": symbol, "interval": interval, "start": start, "end": end}


### PR DESCRIPTION
Changes for IDE style warnings:
- Add pydantic to requirements
- Remove spaces on blank line
- Rename params to avoid conflict with built-in names
- Use pydantic's field_validator instead of the deprecated validator
- Format comments to fit within 120-space line width
- Remove duplicate OptionType class def

Changes for API validation errors:
- Set fields to optional if the API returns a null value
- Set fields to default to None if the API does not always contain those fields
- Change type of various fields to match the values returned by the API (str -> int, int -> float)